### PR TITLE
Change the way properties on document.body are set while loading canvas.

### DIFF
--- a/index-browser.js
+++ b/index-browser.js
@@ -10,17 +10,20 @@ function createGL (opts) {
     canvas = document.createElement('canvas')
     canvas.width = opts.width || window.innerWidth
     canvas.height = opts.height || window.innerHeight
-    if (!opts.width && !opts.height) {
-      // fullscreen
-      document.body.style.margin = '0px'
-    }
-    if (document.body) {
+
+    const appendCanvas = () => {
+      if (!opts.width && !opts.height) {
+        // fullscreen
+        document.body.style.margin = '0px'
+      }
       document.body.appendChild(canvas)
+    }
+
+    if (document.body) {
+      appendCanvas()
     } else {
       // just in case our script is included above <body>
-      document.addEventListener('DOMContentLoaded', () => {
-        document.body.appendChild(canvas)
-      })
+      document.addEventListener('DOMContentLoaded', appendCanvas)
     }
   }
   const gl = canvas.getContext('webgl', opts)


### PR DESCRIPTION
In the default setup, when no width and height options are passed and
`createGL` is called on page load, it throws an error if the script is
included before the body element, since `document.body.style` is null.
The function already accounts for this fact while appending the canvas
to the page, but not while setting `style.margin = '0px'`. This PR
changes that.